### PR TITLE
Trying to revert application.yml to production working mode.

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -22,9 +22,9 @@ spring:
 
   datasource:
     url: ${DATABASE_URL}
-    username: ${DATABASE_USERNAME}
-    password: ${DATABASE_PASSWORD}
-    #driver-class-name: org.postgresql.Driver
+    #    username: ${DATABASE_USERNAME}
+    #    password: ${DATABASE_PASSWORD}
+    #    driver-class-name: org.postgresql.Driver
     driver-class-name: com.microsoft.sqlserver.jdbc.SQLServerDriver
   jpa:
     defer-datasource-initialization: true


### PR DESCRIPTION
The site has crashed and it seems from the azure server log stream that there is a problem with the sql server dialect and JPA. I don't know why that is because it worked before. But this change will revert to exactly the same settings as it was when we ran the server on Azure in the beginning of August.